### PR TITLE
Use Google tagmanger instead of Google Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="ko">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer',"%REACT_APP_TAGMANAGER_CONTAINER_ID%");</script>
+    <!-- End Google Tag Manager -->
+
     <meta charset="utf-8" />
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
@@ -20,18 +24,12 @@
     />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Sans+KR:400,700&display=swap&subset=korean" />
     <title>Piction</title>
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GA_TRACKING_ID%"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', '%REACT_APP_GA_TRACKING_ID%');
-    </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=%REACT_APP_TAGMANAGER_CONTAINER_ID%" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="app-root" class="root"></div>
     <div id="external-root"></div>


### PR DESCRIPTION
GA 글로벌 사이트 태그를 직접 사용하는 방식에서 태그매니터를 사용하는 방식으로 변경합니다.

환경 변수 중 `REACT_APP_GA_TRACKING_ID`는 이제 사용되지 않습니다.

태그매니저 컨테이너 아이디는 `REACT_APP_TAGMANAGER_CONTAINER_ID` 환경 변수를 사용합니다.