### PR TITLE
Prevent all project link from expanding contents

### DIFF
--- a/src/pages/AllProjectsPage/index.jsx
+++ b/src/pages/AllProjectsPage/index.jsx
@@ -38,6 +38,7 @@ const Styled = {
   `,
   Link: styled(Link)`
     grid-column: span 3;
+    overflow: hidden;
   `,
   CardText: styled.p`
     overflow: hidden;


### PR DESCRIPTION
![스크린샷 2019-10-23 오전 9 18 31](https://user-images.githubusercontent.com/1006872/67345571-76d30e00-f576-11e9-970f-29122c0b2f00.png)

firefox에서 이미지가 큰 경우 `Styled.Link`의 grid column을 비집고 나오는 현상이 있어 `overflow: hidden` 속성을 추가했습니다.