### PR TITLE
던파 공모전 피쳐 항목 1건 교체

### DIFF
--- a/src/pages/Campaigns/DNFCreativeLeague/Featured/images.json
+++ b/src/pages/Campaigns/DNFCreativeLeague/Featured/images.json
@@ -4,8 +4,8 @@
     "image": "https://cdn.piction.network/projects/208/posts/cover/1572303962183.jpg"
   },
   {
-    "path": "https://piction.network/project/tan-co/",
-    "image": "https://cdn.piction.network/projects/95/posts/cover/1571213496656.png"
+    "path": "https://piction.network/project/dolechan/",
+    "image": "https://cdn.piction.network/projects/86/posts/cover/1572256817768.PNG"
   },
   {
     "path": "https://piction.network/project/dayeon01/",


### PR DESCRIPTION
던파 공모전 참여가 아닌 프로젝트가 하나 껴 있어서 교체합니다.