### PR TITLE
비밀번호 마스크 처리 버그 수정

### DIFF
--- a/src/components/atoms/Input/PasswordInput.jsx
+++ b/src/components/atoms/Input/PasswordInput.jsx
@@ -24,15 +24,15 @@ const Styled = {
 };
 
 function PasswordInput(props) {
-  const [isVisible, setIsVisible] = useState(true);
+  const [isMasked, setIsMasked] = useState(true);
 
   return (
     <Styled.Wrapper>
-      <Styled.Input {...props} type={isVisible ? 'password' : 'text'} />
-      <Styled.Toggle onClick={() => setIsVisible(visibility => !visibility)}>
-        {isVisible
-          ? <VisibleIcon />
-          : <InvisibleIcon />
+      <Styled.Input {...props} type={isMasked ? 'password' : 'text'} />
+      <Styled.Toggle onClick={() => setIsMasked(prev => !prev)}>
+        {isMasked
+          ? <InvisibleIcon />
+          : <VisibleIcon />
         }
       </Styled.Toggle>
     </Styled.Wrapper>

--- a/src/components/atoms/Input/index.jsx
+++ b/src/components/atoms/Input/index.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const Input = styled.input.attrs({
-  type: 'text',
-})`
+const Input = styled.input.attrs(({ type }) => ({
+  type,
+}))`
   padding: 14px;
   border: 2px solid var(--gray--dark);
   background-color: var(--white);
@@ -28,3 +29,11 @@ const Input = styled.input.attrs({
 `;
 
 export default Input;
+
+Input.propTypes = {
+  type: PropTypes.string,
+};
+
+Input.defaultProps = {
+  type: 'text',
+};


### PR DESCRIPTION
`Input`의 attrs에서 정의한 `type: 'text'`가 `PasswordInput`에서 정의한 `type`을 무시하고 적용되는 문제가 있어 수정했습니다.

`PasswordInput`의 state 변수명이 직관적이지 않아 수정했습니다.