### PR TITLE
Chrome 80 에서 그리드가 깨지는 버그 수정

### DIFF
--- a/src/styles/Grid.jsx
+++ b/src/styles/Grid.jsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components/macro';
 
 export const GridStyle = css`
   display: grid;
-  grid-template-columns: repeat(${({ columns }) => columns}, 1fr);
+  grid-template-columns: repeat(${({ columns }) => columns}, minmax(0, 1fr));
   column-gap: var(--column-gap);
   row-gap: var(--row-gap);
 `;


### PR DESCRIPTION
https://stackoverflow.com/questions/60193734/grid-template-columns-in-chrome-80-inconsistently-computed

정확하게 확인해보진 못했지만 Chrome 80버전부터 minmax를 계산하는 방식이 달라져서 생긴 버그같습니다.