### PR TITLE
Fix creator profile form crash

### DIFF
--- a/src/components/externals/Modal/index.jsx
+++ b/src/components/externals/Modal/index.jsx
@@ -82,3 +82,11 @@ Modal.propTypes = {
 };
 
 export default Modal;
+
+const ModalBody = styled.div`
+  margin-bottom: 24px;
+`;
+
+export {
+  ModalBody,
+};

--- a/src/components/organisms/CreatorProfileForm/index.jsx
+++ b/src/components/organisms/CreatorProfileForm/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
 import useSWR from 'swr';
@@ -14,6 +14,7 @@ import Heading from 'components/atoms/Heading';
 import Input from 'components/atoms/Input';
 import Label from 'components/atoms/Label';
 import { PrimaryButton } from 'components/atoms/Button';
+import Modal, { ModalBody } from 'components/externals/Modal';
 
 const Styled = {
   Form: styled(Grid).attrs({
@@ -82,6 +83,7 @@ const Styled = {
 
 function CreatorProfileForm({ title }) {
   const [API] = useAPI();
+  const [modalBody, setModalBody] = useState(null);
 
   const { data: profile } = useSWR(() => 'my/creator-profiles', {
     revalidateOnFocus: false,
@@ -107,57 +109,67 @@ function CreatorProfileForm({ title }) {
       } else {
         await API.creatorProfile.create(data);
       }
+      setModalBody('입력하신 내용이 저장되었습니다.');
     } catch (error) {
-      console.log(error);
+      setModalBody('서버가 응답하지 않습니다. 잠시 후 다시 시도해주세요.');
     }
   };
 
   return (
-    <Styled.Form onSubmit={handleSubmit(onSubmit)}>
-      <Heading>{title}</Heading>
-      <Styled.InputGroup>
-        <Label htmlFor="greetings">소개</Label>
-        <Styled.Textarea
-          id="greetings"
-          name="greetings"
-          ref={register}
-        />
-      </Styled.InputGroup>
-      <Styled.InputGroup>
-        <Label>외부 링크</Label>
-        {fields.map((field, index) => (
-          <Styled.Field key={field.id}>
-            <Styled.Url>
-              <Input
-                name={`links[${index}].url`}
+    <>
+      {modalBody && (
+        <Modal close={() => setModalBody(null)}>
+          <ModalBody>{modalBody}</ModalBody>
+          <PrimaryButton onClick={() => setModalBody(null)}>확인</PrimaryButton>
+        </Modal>
+      )}
+
+      <Styled.Form onSubmit={handleSubmit(onSubmit)}>
+        <Heading>{title}</Heading>
+        <Styled.InputGroup>
+          <Label htmlFor="greetings">소개</Label>
+          <Styled.Textarea
+            id="greetings"
+            name="greetings"
+            ref={register}
+          />
+        </Styled.InputGroup>
+        <Styled.InputGroup>
+          <Label>외부 링크</Label>
+          {fields.map((field, index) => (
+            <Styled.Field key={field.id}>
+              <Styled.Url>
+                <Input
+                  name={`links[${index}].url`}
+                  ref={register()}
+                  required
+                  placeholder="주소 입력"
+                />
+              </Styled.Url>
+              <Styled.Name
+                name={`links[${index}].name`}
                 ref={register()}
+                maxLength="10"
+                placeholder="이름"
                 required
-                placeholder="주소 입력"
               />
-            </Styled.Url>
-            <Styled.Name
-              name={`links[${index}].name`}
-              ref={register()}
-              maxLength="10"
-              placeholder="이름"
-              required
-            />
-            <Styled.Delete type="button" onClick={() => remove(index)}>
-              <DeleteIcon />
-            </Styled.Delete>
-          </Styled.Field>
-        ))}
-        <Styled.AddLink
-          disabled={fields.length >= 5}
-          onClick={() => append({ name: 'links' })}
-        >
-          + 외부 링크 추가
-        </Styled.AddLink>
-      </Styled.InputGroup>
-      <Styled.SubmitGroup>
-        <Styled.Submit value="저장" />
-      </Styled.SubmitGroup>
-    </Styled.Form>
+              <Styled.Delete type="button" onClick={() => remove(index)}>
+                <DeleteIcon />
+              </Styled.Delete>
+            </Styled.Field>
+          ))}
+          <Styled.AddLink
+            disabled={fields.length >= 5}
+            onClick={() => append({ name: 'links' })}
+          >
+            + 외부 링크 추가
+          </Styled.AddLink>
+        </Styled.InputGroup>
+        <Styled.SubmitGroup>
+          <Styled.Submit value="저장" />
+        </Styled.SubmitGroup>
+      </Styled.Form>
+    </>
   );
 }
 

--- a/src/components/organisms/CreatorProfileForm/index.jsx
+++ b/src/components/organisms/CreatorProfileForm/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components/macro';
 import useSWR from 'swr';
@@ -86,13 +86,15 @@ function CreatorProfileForm({ title }) {
   const { data: profile } = useSWR(() => 'my/creator-profiles', {
     revalidateOnFocus: false,
     shouldRetryOnError: false,
-    suspense: true,
   });
   const {
-    control, register, handleSubmit,
-  } = useForm({
-    defaultValues: profile,
-  });
+    control, register, handleSubmit, reset,
+  } = useForm();
+
+  useEffect(() => {
+    reset(profile);
+  }, [reset, profile]);
+
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'links',

--- a/src/components/organisms/MembershipForm/index.jsx
+++ b/src/components/organisms/MembershipForm/index.jsx
@@ -15,7 +15,7 @@ import Label from 'components/atoms/Label';
 import Heading from 'components/atoms/Heading';
 import Checkbox from 'components/atoms/Checkbox';
 import { PrimaryButton, SecondaryButton, TertiaryButton } from 'components/atoms/Button';
-import Modal from 'components/externals/Modal';
+import Modal, { ModalBody } from 'components/externals/Modal';
 
 import { ReactComponent as TrashbinIcon } from './ic-trashbin.svg';
 
@@ -86,9 +86,6 @@ const Styled = {
   `,
   DangerousButton: styled(PrimaryButton)`
     background-color: var(--red);
-  `,
-  ModalBody: styled.div`
-    margin-bottom: 24px;
   `,
 };
 
@@ -285,13 +282,13 @@ function MembershipForm({
         <Modal close={() => setIsDeletingMembership(false)}>
           {canDeleteMembership ? (
             <>
-              <Styled.ModalBody>선택한 후원 플랜을 삭제하시겠습니까?</Styled.ModalBody>
+              <ModalBody>선택한 후원 플랜을 삭제하시겠습니까?</ModalBody>
               <Styled.DangerousButton onClick={deleteMembership}>삭제</Styled.DangerousButton>
               <TertiaryButton onClick={() => setIsDeletingMembership(false)}>취소</TertiaryButton>
             </>
           ) : (
             <>
-              <Styled.ModalBody>선택한 후원 플랜과 연결된 포스트가 있거나 1명 이상의 구독자가 있어서 삭제가 불가능합니다.</Styled.ModalBody>
+              <ModalBody>선택한 후원 플랜과 연결된 포스트가 있거나 1명 이상의 구독자가 있어서 삭제가 불가능합니다.</ModalBody>
               <PrimaryButton onClick={() => setIsDeletingMembership(false)}>확인</PrimaryButton>
             </>
           )}


### PR DESCRIPTION
창작자 프로필이 생성 되어있지 않은 경우 `suspense: true`로 `useSWR` 요청을 보냈을 때 404 응답으로 uncaught error가 발생합니다.

이 경우를 대응하기 위해 suspense option을 제거하고 비동기적으로 변경되는 `useForm`의 값을 `defaultValues` 대신 `reset`을 사용하여 `useEffect` 내에서 변경값을 적용하는 방식으로 수정했습니다.

또한 `Modal` 컴포넌트를 사용하여 Form submit에 대한 결과를 사용자가 알 수 있도록 하였으며, `Modal` 컴포넌트에 `ModalBody`를 추가하였습니다. 