### PR TITLE
Fix to Management Button URL

### DIFF
--- a/src/components/organisms/ProjectInfo/index.jsx
+++ b/src/components/organisms/ProjectInfo/index.jsx
@@ -279,7 +279,7 @@ function ProjectInfo({
         <Styled.Aside>
           <Styled.Subscribe>
             {isMyProject ? isDesktop && (
-              <Styled.SubscribeButton as={Link} to={`/dashboard/${project.uri}/info`}>
+              <Styled.SubscribeButton as={Link} to={`/dashboard/${project.uri}/posts`}>
                 관리
               </Styled.SubscribeButton>
             ) : sponsored ? (


### PR DESCRIPTION
- 프로젝트 상세에서 관리 버튼 클릭시 리다이렉트 되는 URL 수정 하였습니다.

As-is
크리에이터 대시보드 > 프로젝트 정보 수정

To-be
크리에이터 대시보드 > 포스트 관리