### PR TITLE
update Double quotes char, paths

### DIFF
--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,13 +1,13 @@
 {
-    “applinks”: {
-        “apps”: [],
-        “details”: [
+    "applinks": {
+        "apps": [],
+        "details": [{
+            "appID": "7NU7MY8AU2.network.piction.piction-ios",
+            "paths": ["/project/*/memberships"]
+            },
             {
-                “appID”: [“7NU7MY8AU2.network.piction.piction-ios”,TVSPDRR58A.com.pictionnetwork.piction-test],
-                "components": [
-                    "/": "/project/*/memberships"
-                ]
-            }
-        ]
+            "appID": "TVSPDRR58A.com.pictionnetwork.piction",
+            "paths": ["/project/*/memberships"]
+        }]
     }
 }

--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -6,7 +6,7 @@
             "paths": ["/project/*/memberships"]
             },
             {
-            "appID": "TVSPDRR58A.com.pictionnetwork.piction",
+            "appID": "TVSPDRR58A.com.pictionnetwork.piction-test",
             "paths": ["/project/*/memberships"]
         }]
     }


### PR DESCRIPTION
### iOS Dynamic Links

- "" 쌍 따옴표 문자 변경 : [JSON Validate ](https://jsonlint.com/) 오류나서 보니 인터넷에서 긁어서 넣은 문자의 쌍따옴표가 이상하게 들어가 있었네요... 하아...

- paths 부분을 [애플 개발자 문서](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links)를 따라 수정했습니다.